### PR TITLE
Add script to detect that the DB is initializing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM postgres:13-alpine
 
-
+# Script to detect whether the database has finished initializing
+COPY ["true_isready.sh", "/usr/local/bin/"]
 COPY ["database scripts/00_dump.sql", "database scripts/0[2345]_*.sql", "database scripts/demo_db.sql", "/docker-entrypoint-initdb.d/"]

--- a/true_isready.sh
+++ b/true_isready.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+if [[ $(pgrep -f docker-entrypoint-initdb.d) == "" ]]
+then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
The docker-compose had incorrect healthcheck scripts but was lacking the ability to detect that the initialization was over.
I therefore added a script to detect just that, which can then be used in the docker-compose to have the backend wait for the DB to be fully ready.