### PR TITLE
CM-235: Added CD for develop image of database

### DIFF
--- a/.github/workflows/docker-dev-cd.yml
+++ b/.github/workflows/docker-dev-cd.yml
@@ -1,0 +1,23 @@
+name: publish develop image 
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  publish-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push develop Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: openimis/openimis-pgsql:develop


### PR DESCRIPTION
Automatized unit tests for backend application requires recent develop. Current workflow has to be triggered manually, this PR provides additional workflow that will create database image with most recent changes from develop branch and push it to ghcr repo with "develop" tag. 