### PR TITLE
Feat: Modify the rights of the Claim Administrator and Claim contributor roles

### DIFF
--- a/database scripts/00_dump.sql
+++ b/database scripts/00_dump.sql
@@ -9148,8 +9148,8 @@ INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", 
 INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (183, 11, 131302, CAST(N'2019-05-10T05:08:24.173' AS timestamptz), NULL, NULL, NULL);
 INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (184, 11, 131303, CAST(N'2019-05-10T05:08:24.173' AS timestamptz), NULL, NULL, NULL);
 INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (185, 11, 131304, CAST(N'2019-05-10T05:08:24.177' AS timestamptz), NULL, NULL, NULL);
-INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (186, 9, 111010, CAST(N'2025-11-17T05:11:25.173' AS timestamptz), NULL, NULL, NULL);
-INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (187, 10, 101101, CAST(N'2025-11-17T05:11:25.177' AS timestamptz), NULL, NULL, NULL);
+INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (186, 9, 111010, CAST(N'2019-05-10T05:08:24.177' AS timestamptz), NULL, NULL, NULL);
+INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (187, 10, 101101, CAST(N'2019-05-10T05:08:24.177' AS timestamptz), NULL, NULL, NULL);
 
 -- tblUserRole
 INSERT INTO "tblUserRole" ("UserRoleID", "UserID", "RoleID", "ValidityFrom", "ValidityTo", "AudituserID", "LegacyID") VALUES (1, 1, 1, CAST(N'2019-05-10T05:08:23.313' AS timestamptz), NULL, 3, NULL);

--- a/database scripts/00_dump.sql
+++ b/database scripts/00_dump.sql
@@ -9148,6 +9148,8 @@ INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", 
 INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (183, 11, 131302, CAST(N'2019-05-10T05:08:24.173' AS timestamptz), NULL, NULL, NULL);
 INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (184, 11, 131303, CAST(N'2019-05-10T05:08:24.173' AS timestamptz), NULL, NULL, NULL);
 INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (185, 11, 131304, CAST(N'2019-05-10T05:08:24.177' AS timestamptz), NULL, NULL, NULL);
+INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (186, 9, 111010, CAST(N'2025-11-17T05:11:25.173' AS timestamptz), NULL, NULL, NULL);
+INSERT INTO "tblRoleRight" ("RoleRightID", "RoleID", "RightID", "ValidityFrom", "ValidityTo", "AuditUserId", "LegacyID") VALUES (187, 10, 101101, CAST(N'2025-11-17T05:11:25.177' AS timestamptz), NULL, NULL, NULL);
 
 -- tblUserRole
 INSERT INTO "tblUserRole" ("UserRoleID", "UserID", "RoleID", "ValidityFrom", "ValidityTo", "AudituserID", "LegacyID") VALUES (1, 1, 1, CAST(N'2019-05-10T05:08:23.313' AS timestamptz), NULL, 3, NULL);


### PR DESCRIPTION
In this Jira ticket: https://openimis.atlassian.net/browse/OICI-202

Problem described in the ticket:

Claim Administrator role: Users with this role can enter, load, and submit claims. However, they cannot update (modify) claims as expected. Although the interface allows modifying a claim, saving it triggers an error message that prevents the change from being saved.

Claim Contributor role: Users with this role can access the interface to enter claims, but every attempt to create a claim results in an error message, making it impossible to enter claims.

Our action to resolve the issue:
We granted the Claim Administrator role the right to modify claims.
We granted the Claim Contributor role the right to query insured persons.